### PR TITLE
Update Mercedes-Benz G-Class generations: Add Wikipedia reference and clean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,6 @@
 
 This repository contains signal set configurations for the Mercedes G-Class, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Mercedes G-Class.
 
-## Generations
-
-The Mercedes G-Class (also known as G-Wagen or Geländewagen) has evolved through several generations while maintaining its iconic boxy design and legendary off-road capabilities. The vehicle's development began in 1972 as a collaborative project between Daimler-Benz and Steyr-Daimler-Puch, initially at the suggestion of the Shah of Iran for military use:
-
-- **First Generation - W460 (1979-1991)**: The original G-Class was born from military requirements, featuring austere and utilitarian design with angular, boxy styling that became iconic. Built on rugged body-on-frame construction with solid axles and three locking differentials, it offered unparalleled off-road capability. Available in multiple configurations including convertibles, panel vans, and pickup trucks with both short and long wheelbase options. Engine choices ranged from economical diesels (240 GD, 300 GD) to gasoline units (230 G, 280 GE). The interior remained spartan and functional, prioritizing durability over luxury.
-
-- **Second Generation - W461 (1992-2022)**: Running parallel to the W463, this generation served as the utilitarian continuation of the original G-Class philosophy, specifically designed for military, government, and commercial users. Built on the same chassis as the W460 but with W463 powertrain improvements, it featured a 24-volt electrical system for military compatibility and retained solid axles with three locking differentials. Limited civilian editions like the G 280 CDI EDITION.30 PUR and G 300 CDI Professional were offered. This generation earned the nickname "Wolf" in German military service and was used by armed forces worldwide until production ended in 2022.
-
-- **Third Generation - W463 First Generation (1990-2018)**: This marked the G-Class's transformation from purely utilitarian vehicle to luxury SUV over an remarkable 28-year production run. Moving upmarket to compete with the Range Rover, it featured wood trim, leather upholstery, and sophisticated amenities while retaining the iconic exterior. The range expanded to include everything from four-cylinder to twelve-cylinder engines, spawning legendary variants like the G 63 AMG 6×6 and Mercedes-Maybach G 650 Landaulet. Major updates in 1997, 2002, and 2007 continuously modernized the vehicle while AMG variants became increasingly important, producing up to 621 horsepower.
-
-- **Fourth Generation - W463 Second Generation (2018-2024)**: The most comprehensive redesign in G-Class history while maintaining visual DNA. Grew significantly in dimensions to meet safety regulations while switching to independent front suspension and variable-ratio rack-and-pinion steering. Featured dual 12-inch displays, smartphone integration, and vastly improved build quality. Initial lineup included G 500/G 550 with 4.0L twin-turbo V8 and Mercedes-AMG G 63 with 577 hp, later adding clean diesel variants. Notable editions included the Final Edition G 500 V8 in 2023, marking the end of V8 power in non-AMG models.
-
-- **Fifth Generation - W465 (2024-present)**: The latest evolution focusing on electrification and efficiency while maintaining off-road prowess. Features a new 3.0L inline-six with 48-volt mild-hybrid technology replacing the previous V8 in the G 500, producing 443 horsepower. Most significantly introduces the G 580 with EQ Technology - the first fully electric G-Class with four independent motors producing 579 hp and maintaining the signature three locking differentials. Represents Mercedes-Benz's commitment to preserving G-Class heritage while advancing toward an electrified future.
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Mercedes-Benz_G-Class"
+
 generations:
   - name: "First Generation (W460)"
     start_year: 1979


### PR DESCRIPTION
- Added references section to generations.yaml with Wikipedia source
- Removed duplicate Generations section from README.md (data now exclusive to YAML)
- Verified generational data matches Wikipedia article timeline:
  - W460 (1979-1991): First Generation
  - W461 (1992-2022): Second Generation (military/utilitarian)
  - W463 First Gen (1990-2018): Third Generation (luxury SUV transformation)
  - W463 Second Gen (2018-2024): Fourth Generation (comprehensive redesign)
  - W465 (2024-present): Fifth Generation (electrification focus)

Evidence: Cross-referenced with Mercedes-Benz G-Class Wikipedia article
